### PR TITLE
Add interactivity on Our Team section #7

### DIFF
--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -47,7 +47,7 @@ export default function Team() {
         >
           {people.map(person => (
             <li key={person.name}>
-              <div className="flex items-center gap-x-6">
+              <div className="group flex p-4 rounded-xl items-center gap-x-6 hover:bg-orange-50">
                 <img
                   className="h-16 w-16 rounded-full"
                   src={person.imageUrl}
@@ -57,10 +57,12 @@ export default function Team() {
                   <h3 className="text-base font-semibold leading-7 tracking-tight text-navbar">
                     {person.name}
                   </h3>
-                  <p className="text-sm font-semibold leading-6 text-white">
+                  <p className="text-sm font-semibold leading-6 text-white group-hover:text-navbar">
                     {person.role}
                   </p>
-                  <p className="text-sm leading-6 text-white">{person.desc}</p>
+                  <p className="text-sm leading-6 text-page group-hover:text-navbar">
+                    {person.desc}
+                  </p>
                 </div>
               </div>
             </li>


### PR DESCRIPTION
Fixes #7 
Only show Image, Name and Title for each team member.
Display more details upon hovering card.
<img width="1336" alt="Screenshot 2023-10-13 at 12 27 10 pm" src="https://github.com/dltxio/web3wines-website/assets/92619254/7e2f3fa2-4b94-4f93-ac8b-92acc946d01f">
