### PR TITLE
Show card details upon hovering #8

### DIFF
--- a/src/pages/BlockchainApp.tsx
+++ b/src/pages/BlockchainApp.tsx
@@ -57,7 +57,6 @@ const BlockchainApp: React.FC = () => {
           </div>
           {application.map(item => (
             <Card>
-              <div>
                 <div className="p-8 sm:p-10 lg:flex-auto text-center text-navbar">
                   <h3 className="text-2xl font-bold tracking-tight">
                     {item.name}
@@ -66,7 +65,6 @@ const BlockchainApp: React.FC = () => {
                     {item.desc}
                   </p>
                 </div>
-              </div>
             </Card>
           ))}
         </div>

--- a/src/pages/BlockchainApp.tsx
+++ b/src/pages/BlockchainApp.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect } from "react";
-import { PageLayout } from "../components";
+import { Card, PageLayout } from "../components";
 
 const application = [
   {
@@ -56,16 +56,18 @@ const BlockchainApp: React.FC = () => {
             </p>
           </div>
           {application.map(item => (
-            <div className="mx-auto mt-16 max-w-2xl rounded-3xl ring-1 ring-gray-200 sm:mt-20 lg:mx-0 lg:flex lg:max-w-none">
-              <div className="p-8 sm:p-10 lg:flex-auto">
-                <h3 className="text-2xl font-bold tracking-tight text-navbar">
-                  {item.name}
-                </h3>
-                <p className="mt-6 text-base leading-7 text-white">
-                  {item.desc}
-                </p>
+            <Card>
+              <div>
+                <div className="p-8 sm:p-10 lg:flex-auto text-center text-navbar">
+                  <h3 className="text-2xl font-bold tracking-tight">
+                    {item.name}
+                  </h3>
+                  <p className="mt-6 text-base leading-7 invisible group-hover:visible">
+                    {item.desc}
+                  </p>
+                </div>
               </div>
-            </div>
+            </Card>
           ))}
         </div>
       </div>

--- a/src/pages/Membership.tsx
+++ b/src/pages/Membership.tsx
@@ -37,13 +37,17 @@ const Membership: React.FC = () => {
           </p>
           <div className="mt-6 text-lg leading-8 text-white">
             <p>
-              Fill in{" "}
-              <a href={FORM_LINK} className="underline underline-offset-4">
-                EOI form
-              </a>{" "}
-              or send email to us at info@web3wines.org.
+              Fill in the EOI form or send email to us at info@web3wines.org.
             </p>
             <p>Our team will contact you for further process!</p>
+          </div>
+          <div className="py-4">
+            <a
+              href={FORM_LINK}
+              className="p-3 rounded-xl bg-navbar font-bold hover:bg-orange-50 hover:text-navbar"
+            >
+              Submit EOI
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #8 
Only show card title. Display more details upon hovering.
<img width="1333" alt="Screenshot 2023-10-13 at 1 13 39 pm" src="https://github.com/dltxio/web3wines-website/assets/92619254/77c0fe3d-94e0-4747-8b41-a8be2c37301a">
